### PR TITLE
Reference secrets in reusable workflow

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -17,6 +17,6 @@ jobs:
   publish-charm:
     name: Publish Charm
     uses: ./.github/workflows/publish.yaml
-    with:
+    secrets:
       credentials: "${{ secrets.TEST_SECRET }}"
       github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -25,6 +25,6 @@ jobs:
     name: Publish Charm
     needs: tests
     uses: ./.github/workflows/publish.yaml
-    with:
+    secrets:
       credentials: "${{ secrets.TEST_SECRET }}"
       github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,8 +24,9 @@ jobs:
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@1.0.3
         with:
+          credentials: "${{ secrets.TEST_SECRET }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
-        secrets: inherit
 
   debug:
     name: Debug by establishing a connection to runner


### PR DESCRIPTION
Test if `credentials` will be fetched by the reusable `publish` workflow if specified in `on_push` and `on_pull_request` files.